### PR TITLE
Update requirements for Keras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cython
 matplotlib
 scikit-image
 tensorflow>=1.3.0
-keras>=2.0.8
+keras>=2.0.8,<2.3.0
 opencv-python
 h5py
 imgaug


### PR DESCRIPTION
Keras 2.3.0 removes `metrics_tensors` as an attribute of Models, breaking the following: https://github.com/BerkeleyAutomation/Mask_RCNN/blob/112131a1cf734b29fd7a406c71f77d0f166544ef/mrcnn/model.py#L2200